### PR TITLE
Upgrade gulp-less to 3.0.3 to solve errors

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -23,7 +23,7 @@
     "gulp-imagemin": "^2.0.0",
     "gulp-jshint": "^1.9.0",
     "gulp-json-transform": "^0.2.0",
-    "gulp-less": "^2.0.1",
+    "gulp-less": "^3.0.3",
     "gulp-livereload": "^3.0.2",
     "gulp-sourcemaps": "^1.2.8",
     "gulp-uglify": "^1.0.2",


### PR DESCRIPTION
I've meet undefined error while executing 'styles' task.

My `gulp-less` was installed with these packages.
```
gulp-less@2.0.3 node_modules/gulp-less
├── object-assign@2.0.0
├── convert-source-map@0.4.1
├── through2@0.6.5 (xtend@4.0.0, readable-stream@1.0.33)
├── vinyl-sourcemaps-apply@0.1.4 (source-map@0.1.43)
└── less@2.5.0 (graceful-fs@3.0.6, mime@1.3.4, image-size@0.3.5, promise@6.1.0, errno@0.1.2, mkdirp@0.5.0, source-map@0.4.2, request@2.55.0)
```

Which produces error of `undefined is not a function`:
````
/Users/beata/Documents/chrome-ext/fs-test/node_modules/gulp-less/index.js:68
    }).done(undefined, cb);
       ^
TypeError: undefined is not a function
    at DestroyableTransform._transform (/Users/beata/Documents/chrome-ext/fs-test/node_modules/gulp-less/index.js:68:8)
    at DestroyableTransform.Transform._read (/Users/beata/Documents/chrome-ext/fs-test/node_modules/gulp-less/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.
js:184:10)
    at DestroyableTransform.Transform._write (/Users/beata/Documents/chrome-ext/fs-test/node_modules/gulp-less/node_modules/through2/node_modules/readable-stream/lib/_stream_transform
.js:172:12)
    at doWrite (/Users/beata/Documents/chrome-ext/fs-test/node_modules/gulp-less/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/Users/beata/Documents/chrome-ext/fs-test/node_modules/gulp-less/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/Users/beata/Documents/chrome-ext/fs-test/node_modules/gulp-less/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js
:194:11)
    at write (/Users/beata/Documents/chrome-ext/fs-test/node_modules/gulp-watch/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/Users/beata/Documents/chrome-ext/fs-test/node_modules/gulp-watch/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at Duplex.pipeOnReadable (/Users/beata/Documents/chrome-ext/fs-test/node_modules/gulp-watch/node_modules/readable-stream/lib/_stream_readable.js:664:5)
    at Duplex.emit (events.js:104:17)
```



I figure out that this problem can be solved after upgrade gulp-less to v3.0.3.