### PR TITLE
Iterate recursively to handle vendor-specific keys

### DIFF
--- a/app/templates/tasks/lib/applyBrowserPrefixesFor.js
+++ b/app/templates/tasks/lib/applyBrowserPrefixesFor.js
@@ -15,25 +15,43 @@
  * @param  {Object} manifest
  * @return {Object}
  */
-export default function applyBrowserPrefixesFor(vendor){
-  return function(manifest){
-    Object.keys(manifest).forEach((key)=>{
+export default function applyBrowserPrefixesFor(_vendor){
+  vendor = _vendor;
+  return iterator;
+};
+
+
+/**
+ * Vendor key
+ * @type {String}
+ */
+var vendor = '';
+
+
+/**
+ * Recursive iterator over all object keys
+ * @param  {Object} obj    Object to iterate over
+ * @return {Object}        Processed object
+ */
+function iterator(obj){
+    Object.keys(obj).forEach((key)=>{
       let match = key.match(/^__(chrome|firefox|opera)__(.*)/);
+      if(match){
 
-      if(!match){
-        return;
+        // Swap key with non prefixed name
+        if(match[1] === vendor){
+          obj[match[2]] = obj[key];
+        }
+
+        // Remove the prefixed key
+        // so it won't cause warings
+        delete obj[key];
       }
-
-      // Swap key with non prefixed name
-      if(match[1] === vendor){
-        manifest[match[2]] = manifest[key];
+      else {    // no match? try deeper
+        // Recurse over object's inner keys
+        if (typeof(obj[key]) === "object") iterator(obj[key]);
       }
-
-      // Remove the prefixed key
-      // so it won't cause warings
-      delete manifest[key];
 
     });
-    return manifest;
-  }
-};
+    return obj;
+}


### PR DESCRIPTION
This resolves child keys, for example:

```
{
 "browser_action": {
    "default_popup": "pages/popup.html",
    "__firefox__browser_style": true
  },
  "options_ui": {
    "page": "pages/options.html",
    "__chrome__chrome_style": true
  },
  "__firefox__applications": {
    "...": "..."
  }
}
```

Note,  if there's a *prefix-vendor match*,  we [don't ](https://github.com/HaNdTriX/generator-chrome-extension-kickstart/compare/master...oori:oori-patch-vendor?expand=1#diff-f92cc1fb4bc29ad3b14404f21a906b0eR50)iterate on child keys, it doesn't make sense.   if the parent key is already vendor-specific,  its children keys don't need to be prefixed.