### PR TITLE
Add 'build' task as a dependent task for `pack`

### DIFF
--- a/app/templates/tasks/pack.js
+++ b/app/templates/tasks/pack.js
@@ -13,7 +13,7 @@ function getPackFileType(){
   }
 }
 
-gulp.task('pack', () => {
+gulp.task('pack', ['build'], () => {
   let name = packageDetails.name;
   let version = packageDetails.version;
   let filetype = getPackFileType();


### PR DESCRIPTION
For gulp tasks. I think it makes more sense to `build` before `pack`.